### PR TITLE
REMS-92 saving .env file error fix - test1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,6 @@ jobs:
       - run: |
           cd ./backend
           touch .env
-          echo "${{ secrets.PROD }}" > .env
+          printf "%s\n" "${{ secrets.PROD }}" > .env
       - run: pm2 start all
       - run: pm2 restart all


### PR DESCRIPTION
Saving .env file error fix - test1

Reason could be github action environment variable saved as multiline.